### PR TITLE
AIA-96 - Fix the module loading on boot

### DIFF
--- a/libcutils/probe_module.c
+++ b/libcutils/probe_module.c
@@ -36,15 +36,14 @@ extern int delete_module(const char *, unsigned int);
  */
 char *get_default_mod_path(char *def_mod_path)
 {
-    int len;
     struct utsname buf;
     uname(&buf);
-    len = snprintf(def_mod_path, PATH_MAX, "%s", LDM_DEFAULT_MOD_PATH);
-    strcpy(def_mod_path + len, buf.release);
+    snprintf(def_mod_path, PATH_MAX, "%s/%s", LDM_DEFAULT_MOD_PATH, buf.release);
     if (access(def_mod_path, F_OK))
-        def_mod_path[len] = '\0';
+        snprintf(def_mod_path, PATH_MAX, "%s/", LDM_DEFAULT_MOD_PATH);
     else
         strcat(def_mod_path, "/");
+
     return def_mod_path;
 }
 

--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -239,6 +239,9 @@ on init
     # set RLIMIT_NICE to allow priorities from 19 to -20
     setrlimit 13 40 40
 
+    rm /dev/.coldboot_done
+    restart ueventd
+
 # Healthd can trigger a full boot from charger mode by signaling this
 # property when the power button is held.
 on property:sys.boot_from_charger_mode=1


### PR DESCRIPTION
Tested on both Grub and KF based boot. All modules get loaded correctly now. 