### PR TITLE
Enable ALLOW_PERMISSIVE_LINUX for user build

### DIFF
--- a/init/Android.mk
+++ b/init/Android.mk
@@ -7,7 +7,7 @@ LOCAL_PATH:= $(call my-dir)
 ifneq (,$(filter userdebug eng,$(TARGET_BUILD_VARIANT)))
 init_options += -DALLOW_LOCAL_PROP_OVERRIDE=1 -DALLOW_PERMISSIVE_SELINUX=1
 else
-init_options += -DALLOW_LOCAL_PROP_OVERRIDE=0 -DALLOW_PERMISSIVE_SELINUX=0
+init_options += -DALLOW_LOCAL_PROP_OVERRIDE=0 -DALLOW_PERMISSIVE_SELINUX=1
 endif
 
 init_options += -DLOG_UEVENTS=0


### PR DESCRIPTION
Modify ALLOW_PERMISSIVE_SELINUX=1 for building user verison
to get into homescreen

Bug ID: https://01.org/jira/browse/AIA-340
Test: Test it on Joule and build user version It could get into homescreen

Signed-off-by: Zhou,Jianfengx <jianfengx.zhou@intel.com>
Signed-off-by: hu,xiaopingx <xiaopingx.hu@intel.com>
Signed-off-by: Chen,Xihua <xihua.chen@intel.com>
Signed-off-by: Li,Biyi <biyi.li@intel.com>